### PR TITLE
Make: Remove SDL input delay on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,13 @@ CFLAGS += \
 	-I$(CURDIR)/include \
 	-I$(CURDIR)/src \
 	-DLWIP_HTTPC_HAVE_FILE_IO \
+	-DSDL_DISABLE_JOYSTICK_INIT_DELAY \
 	-O2
 CXXFLAGS += \
 	-I$(CURDIR)/include \
 	-I$(CURDIR)/src \
 	-DLWIP_HTTPC_HAVE_FILE_IO \
+	-DSDL_DISABLE_JOYSTICK_INIT_DELAY \
 	-O2
 
 #Include lvgl main library


### PR DESCRIPTION
nxdk's joystick backend has a delay on startup to allow the usb stack to enumerate controllers to alleviate the fact that most SDL apps do not do hotplugging correctly.

Since you do it correctly this delay can be disabled :)

Decreases bootup time by atleast 0.5 seconds.